### PR TITLE
Add explicit requiring Set from standard library

### DIFF
--- a/lib/hotcell.rb
+++ b/lib/hotcell.rb
@@ -1,4 +1,5 @@
 require 'active_support/all'
+require 'set'
 require 'hotcell/version'
 require 'hotcell/resolver'
 require 'hotcell/config'


### PR DESCRIPTION
- Due to ActiveSupport modules autoloading Set class is not loaded after require 'active_support/all' therefore require 'hotcell' fails in clean environment

Before:

```
ruby -I /Users/gordon/dev/hotcell/lib lib/hotcell.rb
/Users/gordon/dev/hotcell/lib/hotcell/tong.rb:8:in `block in <module:Mixin>': uninitialized constant Hotcell::Tong::Mixin::Set (NameError)
    from /Users/gordon/.rvm/gems/ruby-2.0.0-p247@hotcell/gems/activesupport-4.0.0/lib/active_support/concern.rb:114:in `class_eval'
    from /Users/gordon/.rvm/gems/ruby-2.0.0-p247@hotcell/gems/activesupport-4.0.0/lib/active_support/concern.rb:114:in `append_features'
    from /Users/gordon/dev/hotcell/lib/hotcell/tong.rb:47:in `include'
    from /Users/gordon/dev/hotcell/lib/hotcell/tong.rb:47:in `<class:Tong>'
    from /Users/gordon/dev/hotcell/lib/hotcell/tong.rb:2:in `<module:Hotcell>'
    from /Users/gordon/dev/hotcell/lib/hotcell/tong.rb:1:in `<top (required)>'
    from /Users/gordon/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:112:in `require'
    from /Users/gordon/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:112:in `require'
    from lib/hotcell.rb:17:in `<main>'
```

After:

```
ruby -I /Users/gordon/dev/hotcell/lib lib/hotcell.rb
echo $?
0
```
